### PR TITLE
fix: conditional printing of sensitive data

### DIFF
--- a/examples/model_card_output/template/html/default_template.html.jinja
+++ b/examples/model_card_output/template/html/default_template.html.jinja
@@ -30,7 +30,7 @@
         <div class="col card">
           {% if dataset.name %}<h3>{{ dataset.name }}</h3>{% endif %}
             {% if dataset.description %}<p>{{ dataset.description }}</p>{% endif %}
-            {% if dataset.sensitive %}
+            {% if dataset.sensitive.sensitive_data %}
               <h4>Sensitive data</h4>
               <ul>
               {% for sensitive_data in dataset.sensitive.sensitive_data %}

--- a/verifyml/model_card_toolkit/template/html/default_template.html.jinja
+++ b/verifyml/model_card_toolkit/template/html/default_template.html.jinja
@@ -30,7 +30,7 @@
         <div class="col card">
           {% if dataset.name %}<h3>{{ dataset.name }}</h3>{% endif %}
             {% if dataset.description %}<p>{{ dataset.description }}</p>{% endif %}
-            {% if dataset.sensitive %}
+            {% if dataset.sensitive.sensitive_data %}
               <h4>Sensitive data</h4>
               <ul>
               {% for sensitive_data in dataset.sensitive.sensitive_data %}


### PR DESCRIPTION
"Sensitive data" should also be displayed on the HTML template if `sensitive_data` attribute is present